### PR TITLE
WIP: Split the API

### DIFF
--- a/ims/cli/cli.py
+++ b/ims/cli/cli.py
@@ -61,6 +61,29 @@ def cli():
     pass
 
 
+@cli.command(name='create_disk', short_help="Create a Disk")
+@click.argument(constants.PROJECT_PARAMETER)
+@click.argument(constants.DISK_NAME_PARAMETER)
+@click.argument(constants.IMAGE_NAME_PARAMETER)
+def create_disk(project, disk_name, img):
+    """
+    Create a disk
+
+    \b
+    Arguments:
+    PROJECT     = The HIL Project attached to your credentials
+    DISK_NAME   = The Name of the Disk to create
+    IMG         = The Name of the Image to use
+    """
+    data = {constants.PROJECT_PARAMETER: project,
+            constants.DISK_NAME_PARAMETER: disk_name,
+            constants.IMAGE_NAME_PARAMETER: img}
+    res = requests.put(_url + "create_disk", data=data,
+                       auth=(_username, _password))
+    # We should probably make a PrettyTable here
+    click.echo(res.content)
+
+
 @cli.command(name='pro', short_help="Provision a Node")
 @click.argument(constants.PROJECT_PARAMETER)
 @click.argument(constants.NODE_NAME_PARAMETER)
@@ -269,7 +292,7 @@ def list_projects():
         ret = bmi.list_projects()
         if ret[constants.STATUS_CODE_KEY] == 200:
             table = PrettyTable(
-                field_names=["Id", "Name", "Provision Network"])
+                field_names=["Id", "Name"])
             projects = ret[constants.RETURN_VALUE_KEY]
             for project in projects:
                 table.add_row(project)

--- a/ims/common/constants.py
+++ b/ims/common/constants.py
@@ -83,12 +83,14 @@ MESSAGE_KEY = 'msg'
 # Commands
 LIST_IMAGES_COMMAND = "list_images"
 CREATE_SNAPSHOT_COMMAND = "create_snapshot"
+CREATE_DISK_COMMAND = "create_disk"
+DELETE_DISK_COMMAND = "delete_disk"
 PROVISION_COMMAND = "provision"
-DEPROVISION_COMMAND = "deprovision"
 LIST_SNAPSHOTS_COMMAND = "list_snapshots"
 REMOVE_IMAGE_COMMAND = "remove_image"
 
 # Parameters
+DISK_NAME_PARAMETER = 'disk_name'
 NODE_NAME_PARAMETER = 'node'
 IMAGE_NAME_PARAMETER = "img"
 SNAP_NAME_PARAMETER = "snap_name"

--- a/ims/einstein/operations.py
+++ b/ims/einstein/operations.py
@@ -211,105 +211,108 @@ class BMI:
         self.db.close()
 
     # Provisions from HIL and Boots the given node with given image
-    @log
-    def provision(self, node_name, img_name, nic):
-        try:
-            mac_addr = "01-" + self.hil.get_node_mac_addr(node_name). \
-                replace(":", "-")
 
+    @log
+    def create_disk(self, disk_name, img_name):
+        """
+        Creates a new image named <disk_name> from <img_name>,
+        and then creates an iscsi endpoint for <disk_name>.
+        Returns the disk image name (which also happens to be the iscsi target
+        name)
+
+        Note: The name of the iscsi target and the name of disk in ceph is same
+        """
+
+        # Database Operations
+        try:
+            # Find the image id by using the image name, and then create a new
+            # entry for the new disk image.
             parent_id = self.db.image.fetch_id_with_name_from_project(img_name,
                                                                       self.proj
                                                                       )
-            self.db.image.insert(node_name, self.pid, parent_id)
-            clone_ceph_name = self.__get_ceph_image_name(node_name)
+            self.db.image.insert(disk_name, self.pid, parent_id)
+
+            # This generates the name that BMI *must* have used when it created
+            # the copy in ceph of img_name
             ceph_img_name = self.__get_ceph_image_name(img_name)
+
+            # Prepare the ceph image name to be used.
+            clone_ceph_name = self.__get_ceph_image_name(disk_name)
+        except DBException as e:
+            logger.exception('')
+            return self.__return_error(e)
+
+        # Storage Operations
+        try:
             self.fs.clone(ceph_img_name, constants.DEFAULT_SNAPSHOT_NAME,
                           clone_ceph_name)
-            ceph_config = self.cfg.fs
-            logger.debug("Contents of ceph_config = %s", str(ceph_config))
+        except FileSystemException as e:
+            logger.exception('')
+            self.db.image.delete_with_name_from_project(node_name, self.proj)
+
+        # iSCSI Operations
+        try:
             self.iscsi.add_target(clone_ceph_name)
-            logger.info("The create command was executed successfully")
-            self.__register(node_name, img_name, clone_ceph_name, mac_addr)
+        except ISCSIException as e:
+            logger.exception('')
+            self.fs.remove(clone_ceph_name)
+            self.db.image.delete_with_name_from_project(node_name, self.proj)
+
+        logger.info("The create_disk command was executed successfully")
+
+        # This will be changed to return a list of all targets, with each
+        # target including the endpoint, port and target name.
+        return self.__return_success(clone_ceph_name)
+
+    @log
+    def delete_disk(self, disk_name):
+        """
+        Deletes the disk image <disk_name>. Also deletes the iSCSI target
+        pointing to that image.
+        """
+        try:
+            # Get the ceph image name.
+            ceph_img_name = self.__get_ceph_image_name(disk_name)
+        except DBException as e:
+            logger.exception('')
+            return self.__return_error(e)
+
+        try:
+            self.iscsi.remove_target(ceph_img_name)
+        except ISCSIException as e:
+            logger.exception('')
+            return self.__return_error(e)
+
+        try:
+            ret = self.fs.remove(str(ceph_img_name).encode("utf-8"))
+        except FileSystemException as e:
+            # what if this fails? Also, we should check if it doesnt exists
+            # in ceph then continue, otherwise raise an error.
+            self.isci.add_target(ceph_img_name)
+            return self.__return_error(e)
+
+        # If __get_ceph_image_name(disk_name) passes, then it confirms that
+        # existence of disk_name, and then this delete from db command should
+        # succeed. Will think more if I need to wrap this up in a try except
+        # block.
+        self.db.image.delete_with_name_from_project(disk_name, self.proj)
+        return self.__return_success(ret)
+
+    @log
+    def provision(self, node_name, disk_name, nic):
+        """
+        This takes in the name of the disk, and then creates the ipxe
+        and macaddress file for <node> with <nic>
+        """
+        try:
+            mac_addr = "01-" + self.hil.get_node_mac_addr(node_name). \
+                replace(":", "-")
+            clone_ceph_name = self.__get_ceph_image_name(disk_name)
+            self.__register(node_name, disk_name, clone_ceph_name, mac_addr)
             return self.__return_success(True)
 
-        except RegistrationFailedException as e:
+        except (RegistrationFailedException, DBException, HILException) as e:
             # Message is being handled by custom formatter
-            # TODO: add a deployment and a unit test for this case.
-            logger.exception('')
-            clone_ceph_name = self.__get_ceph_image_name(node_name)
-            self.iscsi.remove_target(clone_ceph_name)
-            self.fs.remove(clone_ceph_name)
-            self.db.image.delete_with_name_from_project(node_name, self.proj)
-            time.sleep(constants.HIL_CALL_TIMEOUT)
-            return self.__return_error(e)
-
-        except ISCSIException as e:
-            # Message is being handled by custom formatter
-            logger.exception('')
-            clone_ceph_name = self.__get_ceph_image_name(node_name)
-            self.fs.remove(clone_ceph_name)
-            self.db.image.delete_with_name_from_project(node_name, self.proj)
-            time.sleep(constants.HIL_CALL_TIMEOUT)
-            return self.__return_error(e)
-
-        except FileSystemException as e:
-            # Message is being handled by custom formatter
-            logger.exception('')
-            self.db.image.delete_with_name_from_project(node_name, self.proj)
-            time.sleep(constants.HIL_CALL_TIMEOUT)
-            return self.__return_error(e)
-        except DBException as e:
-            # Message is being handled by custom formatter
-            logger.exception('')
-            time.sleep(constants.HIL_CALL_TIMEOUT)
-            return self.__return_error(e)
-        except HILException as e:
-            # Message is being handled by custom formatter
-            logger.exception('')
-            return self.__return_error(e)
-
-    # This is for detach a node and removing it from iscsi
-    # and destroying its image
-    @log
-    def deprovision(self, node_name, nic):
-        ceph_img_name = None
-        try:
-            ceph_img_name = self.__get_ceph_image_name(node_name)
-            self.db.image.delete_with_name_from_project(node_name, self.proj)
-            ceph_config = self.cfg.fs
-            logger.debug("Contents of ceph+config = %s", str(ceph_config))
-            self.iscsi.remove_target(ceph_img_name)
-            logger.info("The delete command was executed successfully")
-            ret = self.fs.remove(str(ceph_img_name).encode("utf-8"))
-            return self.__return_success(ret)
-
-        except FileSystemException as e:
-            logger.exception('')
-            self.iscsi.add_target(ceph_img_name)
-            parent_name = self.fs.get_parent_info(ceph_img_name)[1]
-
-            parent_id = self.db.image.fetch_id_with_name_from_project(
-                parent_name,
-                self.proj)
-            self.db.image.insert(node_name, self.pid, parent_id,
-                                 id=self.__extract_id(ceph_img_name))
-            time.sleep(constants.HIL_CALL_TIMEOUT)
-            return self.__return_error(e)
-        except ISCSIException as e:
-            logger.exception('')
-            parent_name = self.fs.get_parent_info(ceph_img_name)[1]
-            parent_id = self.db.image.fetch_id_with_name_from_project(
-                parent_name,
-                self.proj)
-            self.db.image.insert(node_name, self.pid, parent_id,
-                                 id=self.__extract_id(ceph_img_name))
-            time.sleep(constants.HIL_CALL_TIMEOUT)
-            return self.__return_error(e)
-        except DBException as e:
-            logger.exception('')
-            time.sleep(constants.HIL_CALL_TIMEOUT)
-            return self.__return_error(e)
-        except HILException as e:
             logger.exception('')
             return self.__return_error(e)
 

--- a/ims/picasso/rest.py
+++ b/ims/picasso/rest.py
@@ -82,15 +82,9 @@ def list_images():
 
 
 @rest_call("/provision/", 'PUT', constants.PROVISION_COMMAND,
-           [constants.NODE_NAME_PARAMETER, constants.IMAGE_NAME_PARAMETER,
+           [constants.NODE_NAME_PARAMETER, constants.DISK_NAME_PARAMETER,
             constants.NIC_PARAMETER])
 def provision():
-    pass
-
-
-@rest_call("/deprovision/", "DELETE", constants.DEPROVISION_COMMAND,
-           [constants.NODE_NAME_PARAMETER, constants.NIC_PARAMETER])
-def deprovision():
     pass
 
 
@@ -108,4 +102,16 @@ def list_snapshots():
 @rest_call("/remove_image/", "DELETE", constants.REMOVE_IMAGE_COMMAND,
            [constants.IMAGE_NAME_PARAMETER])
 def remove_image():
+    pass
+
+
+@rest_call("/create_disk", "PUT", constants.CREATE_DISK_COMMAND,
+           [constants.DISK_NAME_PARAMETER, constants.IMAGE_NAME_PARAMETER])
+def create_disk():
+    pass
+
+
+@rest_call("/delete_disk", "DELETE", constants.DELETE_DISK_COMMAND,
+           [constants.DISK_NAME_PARAMETER])
+def delete_disk():
     pass

--- a/ims/rpc/client/rpc_client.py
+++ b/ims/rpc/client/rpc_client.py
@@ -14,6 +14,8 @@ class RPCClient:
         # Loads the variable dict with the contents of config.json.
         self.dict = {
             "function-list": {
+                "create_disk": "2",
+                "delete_disk": "1",
                 "provision": "3",
                 "deprovision": "2",
                 "create_snapshot": "2",


### PR DESCRIPTION
In this PR I split the APIs so that foreman can talk to BMI. This is built on top of #166 

* Another thing this does is that, now it decouples the actual iscsi disk from the physical host. The workflow will now be something like this:
1. User creates a new disk from a golden image. (ceph clone, iscsi target add, db entry)
2. They provision a node to boot form the newly created disk image (macaddress file, ipxe file).
3. They can re-provision the node to point to a different disk image.
4. They can delete a disk_image that they no longer use.

So, foreman can now just call BMI to create disk_image and handle the other bits on it's own.

Notes:
1.  There's no de-provision command right now.
2. This breaks the APIs, so if anything was using the old BMI APIs that will have to be updated to use the new stuff. 

This is a work in progress, I still need to update everything to work with the notion of disk_images now. Opening this up so I can gather feedback on the changes before I go ahead and modify everything else. This is going to be a big one.

Things I still need to update:

- [ ] Update the rest of the methods.
- [ ] Update the REST APIs
- [ ] Update/add tests.
- [ ] Document the new APIs.
- [ ] (Easy) add delete_disk CLI call
- [ ] We should have a way to get an iscsi target without creating a disk.
- [ ] DB no longer can search for images by project, probably something to do with the schema changing here

@ianballou I updated the checklist here with the items you suggested.

cc// @Izhmash @apoorvemohan 