### PR TITLE
Use massopencloud docker registry rathen than bmis because:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ before_script:
   - sleep 30
 
   # Run HIL Container
-  - sudo docker run -d --name hil bmis/hil
+  - sudo docker run -d --name hil massopencloud/hil
 
   # Build BMI Container From Environment Image
-  - sudo docker pull bmis/bmi-ci
+  - sudo docker pull massopencloud/bmi-ci
   - sudo docker build -t bmi-test -f Dockerfile_ci .
   - sudo docker run -d -e TRAVIS=$TRAVIS -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID -e TRAVIS_BRANCH=$TRAVIS_BRANCH -v ceph:/etc/ceph --name bmi bmi-test
 


### PR DESCRIPTION
* we dont have access to bmis docker registry
* we probably want to keep things on massopencloud repos/registries.

Will come in handy when we need to update the docker images. @apoorvemohan @ianballou I can add your accounts to massopencloud docker repo/registry (or whatever they call it)