### PR TITLE
Use ceph-hammer container from massopencloud docker registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - find . -name \*.py -exec python -m py_compile {} +
 
   # Run Ceph Container and Wait for some time so that ceph runs
-  - sudo docker run -d -v ceph:/etc/ceph -e MON_IP=172.17.0.2 -e CEPH_PUBLIC_NETWORK=172.17.0.0/24 --name ceph ceph/demo:tag-build-master-hammer-centos-7
+  - sudo docker run -d -v ceph:/etc/ceph -e MON_IP=172.17.0.2 -e CEPH_PUBLIC_NETWORK=172.17.0.0/24 --name ceph massopencloud/ceph-hammer
   - sleep 30
 
   # Run HIL Container


### PR DESCRIPTION
because it was removed from the the ceph registry for reasons I don't know.
So I uploaded the image to our registry from my PC.

We should probably use a newer version of ceph (either make our own image, or
get it from somewhere) later.